### PR TITLE
Add more attributes for most of the Scaleft Configuration Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,110 @@ Only works with RHEL and Debian based distros.
 
 Attributes
 ----------
+
+** NOTE: if the Default is `nil` below, that means it does not override the
+default of the ScaleFT options as described at
+https://www.scaleft.com/docs/sftd/#common-configuration-options**
+
 #### scaleft::default
 <table>
   <tr>
     <th>Key</th>
     <th>Type</th>
     <th>Description</th>
-    <th>Default</th>
+    <th>Attribute Default</th>
+    <th>ScaleFT Default</th>
   </tr>
   <tr>
     <td><tt>['scaleft']['initial_url']</tt></td>
     <td>String</td>
     <td>your scaleft endpoint</td>
     <td>nil</td>
+    <td>unset</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['access_address']</tt></td>
+    <td>String</td>
+    <td>For hosts with multiple interfaces, or behind DNATs; specifies the address clients will use when connecting to this host</td>
+    <td>nil</td>
+    <td>unset</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['alt_names']</tt></td>
+    <td>String</td>
+    <td>A list of alternative hostnames for this server. These names can be used as targetnames in sft ssh</td>
+    <td>nil</td>
+    <td>unset</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['auto_enroll'] </tt></td>
+    <td>String</td>
+    <td>When true, sftd will attempt to automatically enroll with ScaleFT on initial startup</td>
+    <td>nil</td>
+    <td>true</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['bastion']</tt></td>
+    <td>String</td>
+    <td>Specifies the bastion-host clients will automatically use when connecting to this host</td>
+    <td>nil</td>
+    <td>unset</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['canonical_name']</tt></td>
+    <td>String</td>
+    <td>Specifies the name clients should use/see when connecting to this host. Overrides the name found with `hostname`</td>
+    <td>nil</td>
+    <td>unset</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['log_level']</tt></td>
+    <td>String</td>
+    <td>Controls the logging verbosity. Valid values are WARN, INFO or DEBUG. Runing sftd with the --debug flag is equivalent to configuring a level of DEBUG, and will override values from the config file</td>
+    <td>nil</td>
+    <td>`INFO`</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['buffer_file']</tt></td>
+    <td>String</td>
+    <td>Path-prefix to the file(s) that sftd will use for it’s local buffer store. Individual buffers will have a ‘.’ and an incrementing number will be appended to the path-prefix. BufferFiles which have been synchronized will be removed automatically</td>
+    <td>nil</td>
+    <td>`/var/lib/sftd/buffer.db`</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['enrollment_token_file']</tt></td>
+    <td>String</td>
+    <td>Path to the file containing a secret token for token based enrollment. This file is deleted after a successful enrollment to the platform</td>
+    <td>nil</td>
+    <td>`/var/lib/sftd/enrollment.token`</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['server_file']</tt></td>
+    <td>String</td>
+    <td>Path to the file that sftd uses to store the server URL that it will connect to</td>
+    <td>nil</td>
+    <td>`/var/lib/sftd/device.server`</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['sshd_config_file']</tt></td>
+    <td>String</td>
+    <td>Path to sshd configuration file. *Note sftd will modify this file*</td>
+    <td>nil</td>
+    <td>`/etc/ssh/sshd_config`</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['token_file']</tt></td>
+    <td>String</td>
+    <td>Path to file that sftd uses to store its secret token for authentication to ScaleFT</td>
+    <td>nil</td>
+    <td>`/var/lib/sftd/device.token`</td>
+  </tr>
+  <tr>
+    <td><tt>['scaleft']['trusted_user_ca_file']</tt></td>
+    <td>String</td>
+    <td>Path for sftd to write the list of trusted SSH Certificate authorities to</td>
+    <td>nil</td>
+    <td>`/var/lib/sftd/ssh_ca.pub`</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -27,91 +27,91 @@ https://www.scaleft.com/docs/sftd/#common-configuration-options**
     <td>String</td>
     <td>your scaleft endpoint</td>
     <td>nil</td>
-    <td>unset</td>
+    <td><tt>unset</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['access_address']</tt></td>
     <td>String</td>
     <td>For hosts with multiple interfaces, or behind DNATs; specifies the address clients will use when connecting to this host</td>
     <td>nil</td>
-    <td>unset</td>
+    <td><tt>unset</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['alt_names']</tt></td>
     <td>String</td>
     <td>A list of alternative hostnames for this server. These names can be used as targetnames in sft ssh</td>
     <td>nil</td>
-    <td>unset</td>
+    <td><tt>unset</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['auto_enroll'] </tt></td>
     <td>String</td>
     <td>When true, sftd will attempt to automatically enroll with ScaleFT on initial startup</td>
     <td>nil</td>
-    <td>true</td>
+    <td><tt>true</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['bastion']</tt></td>
     <td>String</td>
     <td>Specifies the bastion-host clients will automatically use when connecting to this host</td>
     <td>nil</td>
-    <td>unset</td>
+    <td><tt>unset</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['canonical_name']</tt></td>
     <td>String</td>
-    <td>Specifies the name clients should use/see when connecting to this host. Overrides the name found with `hostname`</td>
+    <td>Specifies the name clients should use/see when connecting to this host. Overrides the name found with hostname</td>
     <td>nil</td>
-    <td>unset</td>
+    <td><tt>unset</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['log_level']</tt></td>
     <td>String</td>
     <td>Controls the logging verbosity. Valid values are WARN, INFO or DEBUG. Runing sftd with the --debug flag is equivalent to configuring a level of DEBUG, and will override values from the config file</td>
     <td>nil</td>
-    <td>`INFO`</td>
+    <td><tt>INFO</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['buffer_file']</tt></td>
     <td>String</td>
     <td>Path-prefix to the file(s) that sftd will use for it’s local buffer store. Individual buffers will have a ‘.’ and an incrementing number will be appended to the path-prefix. BufferFiles which have been synchronized will be removed automatically</td>
     <td>nil</td>
-    <td>`/var/lib/sftd/buffer.db`</td>
+    <td><tt>/var/lib/sftd/buffer.db</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['enrollment_token_file']</tt></td>
     <td>String</td>
     <td>Path to the file containing a secret token for token based enrollment. This file is deleted after a successful enrollment to the platform</td>
     <td>nil</td>
-    <td>`/var/lib/sftd/enrollment.token`</td>
+    <td><tt>/var/lib/sftd/enrollment.token</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['server_file']</tt></td>
     <td>String</td>
     <td>Path to the file that sftd uses to store the server URL that it will connect to</td>
     <td>nil</td>
-    <td>`/var/lib/sftd/device.server`</td>
+    <td><tt>/var/lib/sftd/device.server</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['sshd_config_file']</tt></td>
     <td>String</td>
     <td>Path to sshd configuration file. *Note sftd will modify this file*</td>
     <td>nil</td>
-    <td>`/etc/ssh/sshd_config`</td>
+    <td><tt>/etc/ssh/sshd_config</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['token_file']</tt></td>
     <td>String</td>
     <td>Path to file that sftd uses to store its secret token for authentication to ScaleFT</td>
     <td>nil</td>
-    <td>`/var/lib/sftd/device.token`</td>
+    <td><tt>/var/lib/sftd/device.token</tt></td>
   </tr>
   <tr>
     <td><tt>['scaleft']['trusted_user_ca_file']</tt></td>
     <td>String</td>
     <td>Path for sftd to write the list of trusted SSH Certificate authorities to</td>
     <td>nil</td>
-    <td>`/var/lib/sftd/ssh_ca.pub`</td>
+    <td><tt>/var/lib/sftd/ssh_ca.pub</tt></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Only works with RHEL and Debian based distros.
 Attributes
 ----------
 
-** NOTE: if the Default is `nil` below, that means it does not override the
+** NOTE: if the `Attribute Default` is `nil` below, that means it does not override the
 default of the ScaleFT options as described at
 https://www.scaleft.com/docs/sftd/#common-configuration-options**
 
@@ -23,9 +23,19 @@ https://www.scaleft.com/docs/sftd/#common-configuration-options**
     <th>ScaleFT Default</th>
   </tr>
   <tr>
+    <td><tt>['scaleft']['initial_url_required']</tt></td>
+    <td>String</td>
+    <td>If set, recreates the same behavior as v0.1.0. I.E. you must supply the initial_url parameter</td>
+    <td>true</td>
+    <td><tt>N/A</tt></td>
+  </tr>
+  <tr>
     <td><tt>['scaleft']['initial_url']</tt></td>
     <td>String</td>
-    <td>your scaleft endpoint</td>
+    <td>When AutoEnroll is set to true, this option specifies the InitialURL 
+    that the server can use to auto-enroll. 
+    When an enrollment.token is provided, this option is ignored. 
+    If you are using the ScaleFT SaaS, you can leave this unset</td>
     <td>nil</td>
     <td><tt>unset</tt></td>
   </tr>
@@ -134,6 +144,25 @@ Just include `scaleft` in your node's `run_list`:
   ]
 }
 ```
+
+#### In a wrapper recipe when using ScaleFT SaaS
+
+```ruby
+node.set['scaleft']['initial_url_required'] = false
+
+node.set['scaleft']['bastion'] = calculate_bastion_name(node['hostname'], node.chef_environment)
+node.set['scaleft']['canonical_name'] = calculate_canonical_name(node['hostname'], node.chef_environment)
+node.set['scaleft']['alt_names'] = calculate_alt_names(node['hostname'], node.chef_environment)
+
+include_recipe "scaleft"
+```
+
+**Note:** The `calculate_*` functions are a placeholder for how you would
+          determine the values of the various parameters at chef-client runtime.
+
+Remeber to add `depends scaleft` to your `metatdata.rb` and this repo to your
+`Berksfile` for your wrapper cookbook.
+
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Only works with RHEL and Debian based distros.
 Attributes
 ----------
 
-** NOTE: if the Default is `nil` below, that means it does not override the
+**NOTE: if the Default is `nil` below, that means it does not override the
 default of the ScaleFT options as described at
 https://www.scaleft.com/docs/sftd/#common-configuration-options**
 

--- a/README.md
+++ b/README.md
@@ -176,3 +176,4 @@ Contributing
 License and Authors
 -------------------
 Authors:: Jim Rosser (jim.rosser@rackspace.com)
+          Robert Berger (rob@omnyway.com)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,25 @@
+# 'initial_url_required' is there to preserve backwards compatable
+# behavior with the original Rackspace version
+# Override it to false to not require 'initial_url' in your
+# environment, role or wrapper cookbook
+default['scaleft']['initial_url_required'] = true
+
+# Values used to set the sftd.yaml config file
+# If set to nil, it won't be written to the file and will use
+# ScaleFT Defaults
+# Override in your environment, role or wrapper cookbook
+# See https://www.scaleft.com/docs/sftd/
+#
 default['scaleft']['initial_url'] = nil
+default['scaleft']['access_address'] = nil
+default['scaleft']['alt_names'] = nil
+default['scaleft']['auto_enroll'] = true
+default['scaleft']['bastion'] = nil
+default['scaleft']['canonical_name'] = nil
+default['scaleft']['log_level'] = nil
+default['scaleft']['buffer_file'] = nil
+default['scaleft']['enrollment_token_file'] = nil
+default['scaleft']['server_file'] = nil
+default['scaleft']['sshd_config_file'] = nil
+default['scaleft']['token_file'] = nil
+default['scaleft']['trusted_user_ca_file'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,18 +42,8 @@ package 'scaleft-server-tools' do
   action :install
 end
 
-directory '/etc/sft' do
-  action :create
-end
-
-if node['scaleft']['initial_url'].nil?
-  fail "The attribute node['scaleft']['initial_url'] must be set"
-end
-
-file '/etc/sft/sftd.yaml' do
-  action :create
-  content "InitialURL: #{node['scaleft']['initial_url']}"
-end
+# Create the config file
+include_recipe "scaleft::sftd_config"
 
 # https://github.com/rackspace-cookbooks/scaleft/issues/2
 execute 'chkconfig_add_sftd' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,12 +38,12 @@ else
   fail "Platform #{node['platform_family']} is not currently supported"
 end
 
+# Create the config file
+include_recipe "scaleft::sftd_config"
+
 package 'scaleft-server-tools' do
   action :install
 end
-
-# Create the config file
-include_recipe "scaleft::sftd_config"
 
 # https://github.com/rackspace-cookbooks/scaleft/issues/2
 execute 'chkconfig_add_sftd' do

--- a/recipes/sftd_config.rb
+++ b/recipes/sftd_config.rb
@@ -32,5 +32,3 @@ template '/etc/sft/sftd.yaml' do
   group 'root'
   mode '0755'
 end
-
-

--- a/recipes/sftd_config.rb
+++ b/recipes/sftd_config.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: scaleft
+# Recipe:: sftd_config
+#
+# Copyright 2017, Omnyway and Rackspace
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+directory '/etc/sft' do
+  action :create
+end
+
+if (node['scaleft']['initial_url_required'] &&
+   node['scaleft']['initial_url'].nil?)
+  fail "The attribute node['scaleft']['initial_url'] must be set"
+end
+
+# Gets all its config from node attributes
+template '/etc/sft/sftd.yaml' do
+  source 'sftd.yaml.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
+

--- a/recipes/sftd_config.rb
+++ b/recipes/sftd_config.rb
@@ -31,4 +31,5 @@ template '/etc/sft/sftd.yaml' do
   owner 'root'
   group 'root'
   mode '0755'
+  notifies :restart, 'service[sftd]', :delayed
 end

--- a/templates/default/sftd.yaml.erb
+++ b/templates/default/sftd.yaml.erb
@@ -1,0 +1,85 @@
+---
+# Common Configuration Options:
+#
+# NOTE: This file managed by Chef.
+# Manual changes will be removed on next chef-client run
+#
+<% sft = node['scaleft'] %>
+
+<% if sft['access_address'] %>
+AccessAddress: <%= sft['access_address'] %>
+<% else %>
+# AccessAddress is unset by default
+<% end %>
+
+<% if sft['alt_names'] %>
+AltNames:  [<%= sft['alt_names'].join(",") %>]
+<% else %>
+# AltNames is unset by default
+<% end %>
+
+<% if sft['auto_enroll'] %>
+AutoEnroll: <%= sft['auto_enroll'] %>
+<% else %>
+# AutoEnroll is unset by default
+<% end %>
+
+<% if sft['bastion'] %>
+Bastion: <%= sft['bastion'] %>
+<% else %>
+# Bastion is unset by default
+<% end %>
+
+<% if sft['canonical_name'] %>
+CanonicalName: <%= sft['canonical_name'] %>
+<% else %>
+# CanonicalName is unset by default
+<% end %>
+
+<% if sft['initial_url'] %>
+InitialURL: <%= sft['initial_url'] %>
+<% else %>
+# InitialURL is unset by default
+<% end %>
+
+<% if sft['log_level'] %>
+LogLevel: <%= sft['log_level'] %>
+<% else %>
+# LogLevel is INFO by default
+<% end %>
+
+<% if sft['buffer_file'] %>
+BufferFile: <%= sft['buffer_file'] %>
+<% else %>
+# BufferFile will use ScaleFT Default value
+<% end %>
+
+<% if sft['enrollment_token_file'] %>
+EnrollmentTokenFile: <%= sft['enrollment_token_file'] %>
+<% else %>
+# EnrollmentTokenFile will use ScaleFT Default value
+<% end %>
+
+<% if sft['server_file'] %>
+ServerFile: <%= sft['server_file'] %>
+<% else %>
+# ServerFile will use ScaleFT Default value
+<% end %>
+
+<% if sft['sshd_config_file'] %>
+SSHDConfigFile: <%= sft['sshd_config_file'] %>
+<% else %>
+# SSHDConfigFile will use ScaleFT Default value
+<% end %>
+
+<% if sft['token_file'] %>
+TokenFile: <%= sft['token_file'] %>
+<% else %>
+# TokenFile will use ScaleFT Default value
+<% end %>
+
+<% if sft['trusted_user_ca_file'] %>
+TrustedUserCAKeysFile: <%= sft['trusted_user_ca_file'] %>
+<% else %>
+# TrustedUserCAKeysFile will use ScaleFT Default value
+<% end %>


### PR DESCRIPTION
Added attributes and broke out the creation of the sftd.yaml based on a template into its own recipe.

Created an attribute:
```
default['scaleft']['initial_url_required'] = true
```
That by default keeps the old behavior of requiring `['scaleft']['initial_url']` to be set.

If `['scaleft']['initial_url_required']`  is not set or is false, then it is not required to set `['scaleft']['initial_url']`. This later behavior is appropriate for the ScaleFT SaaS.

The main feature of this pull request is the addition of a template and attributes to set all the other Common  and Additional Configuration Options as described in https://www.scaleft.com/docs/sftd/#common-configuration-options